### PR TITLE
Add server-side authentication

### DIFF
--- a/models/robot.js
+++ b/models/robot.js
@@ -4,7 +4,7 @@ const mongoose = require("mongoose");
 const robotSchema = new mongoose.Schema({
     name: String,
     connected: Boolean,
-    ipaddress: String,
+    key: String,
 });
 
 // Export model


### PR DESCRIPTION
Closes #7 

This PR adds [middleware to the SocketIO server](https://socket.io/docs/v3/middlewares/) to authenticate incoming connections. It checks the key in the `socket.handshake.headers` object and looks for a robot in the database with the same key. If it finds one, the connection is allowed. Otherwise it refuses the connection and the client is sent an error message.

See https://github.com/automat-ed/autonomous/pull/27 for some changes that were made on the robot side.